### PR TITLE
Modularize classifier training

### DIFF
--- a/notebooks/training.ipynb
+++ b/notebooks/training.ipynb
@@ -1,0 +1,259 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Train TRRUST Classifiers\n",
+    "\n",
+    "Train binary (Relationship vs None) and ternary (Activation vs Repression vs None)\n",
+    "classifiers on TRRUST transcription factor\u2013target gene relationships.\n",
+    "\n",
+    "This notebook is **model-agnostic**: point `EMBEDDINGS_PATH` at any h5ad file\n",
+    "produced by `src/scgpt/encode.py` or `src/geneformer/encode.py` \u2014 both store\n",
+    "gene symbols in `obs_names` and embeddings in `.X`.\n",
+    "\n",
+    "Training outputs (`train_losses`, `test_losses`, `classification_report`,\n",
+    "`gene_predictions`) live on the returned `TrainingResult` object and are\n",
+    "easy to serialize from a downstream notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import torch\n",
+    "\n",
+    "from src.trrust import (\n",
+    "    BINARY_LABELS,\n",
+    "    TERNARY_LABELS,\n",
+    "    load_binary_trrust_data,\n",
+    "    load_gene_embeddings,\n",
+    "    load_ternary_trrust_data,\n",
+    "    prepare_train_test_split,\n",
+    "    train_classifier,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "config-md",
+   "metadata": {},
+   "source": [
+    "## Configuration\n",
+    "\n",
+    "Change `EMBEDDINGS_PATH` to swap foundation models \u2014 the rest of the notebook\n",
+    "does not depend on which model produced the embeddings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "config",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EMBEDDINGS_PATH = Path(\"../data/embeddings/scgpt_human_cd20.h5ad\")\n",
+    "TRRUST_PATH = Path(\"../data/trrust_rawdata.human.tsv\")\n",
+    "DEVICE = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
+    "\n",
+    "BATCH_SIZE = 64\n",
+    "BINARY_LR = 1e-5\n",
+    "TERNARY_LR = 1e-5\n",
+    "BINARY_EPOCHS = 20\n",
+    "TERNARY_EPOCHS = 20\n",
+    "\n",
+    "print(f\"Device: {DEVICE}\")\n",
+    "print(f\"Embeddings: {EMBEDDINGS_PATH}\")\n",
+    "print(f\"TRRUST: {TRRUST_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "load-md",
+   "metadata": {},
+   "source": [
+    "## Load embeddings and TRRUST data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "load",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gene_embeddings = load_gene_embeddings(EMBEDDINGS_PATH)\n",
+    "embsize = next(iter(gene_embeddings.values())).shape[0]\n",
+    "\n",
+    "binary_data = load_binary_trrust_data(TRRUST_PATH, gene_embeddings)\n",
+    "ternary_data = load_ternary_trrust_data(TRRUST_PATH, gene_embeddings)\n",
+    "\n",
+    "print(f\"Gene embeddings: {len(gene_embeddings)} genes, {embsize}d\")\n",
+    "print(f\"Binary samples: {len(binary_data.records)}\")\n",
+    "print(f\"Ternary samples: {len(ternary_data.records)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "binary-md",
+   "metadata": {},
+   "source": [
+    "## Binary classifier\n",
+    "\n",
+    "90/10 stratified train/test split, no class weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "binary-train",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "binary_train_ds, binary_test_ds, binary_test_meta = prepare_train_test_split(\n",
+    "    binary_data, test_size=0.1, seed=42,\n",
+    ")\n",
+    "\n",
+    "binary_result = train_classifier(\n",
+    "    binary_train_ds,\n",
+    "    binary_test_ds,\n",
+    "    binary_test_meta,\n",
+    "    embsize=embsize,\n",
+    "    label_map=BINARY_LABELS,\n",
+    "    lr=BINARY_LR,\n",
+    "    epochs=BINARY_EPOCHS,\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    use_class_weights=False,\n",
+    "    device=DEVICE,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "binary-plot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "epochs = range(1, BINARY_EPOCHS + 1)\n",
+    "plt.figure(figsize=(8, 4))\n",
+    "plt.plot(epochs, binary_result.train_losses, label=\"Train\")\n",
+    "plt.plot(epochs, binary_result.test_losses, label=\"Test\")\n",
+    "plt.xlabel(\"Epoch\")\n",
+    "plt.ylabel(\"Loss\")\n",
+    "plt.title(f\"Binary Classifier Loss, Learning Rate = {BINARY_LR}\")\n",
+    "plt.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "binary-report",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "print(pd.DataFrame(binary_result.classification_report).T.round(3))\n",
+    "print()\n",
+    "print(\"Sample predictions:\")\n",
+    "print(binary_result.gene_predictions.head(10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ternary-md",
+   "metadata": {},
+   "source": [
+    "## Ternary classifier\n",
+    "\n",
+    "90/10 stratified train/test split with inverse-frequency class weights to\n",
+    "handle the Activation/Repression/None imbalance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ternary-train",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ternary_train_ds, ternary_test_ds, ternary_test_meta = prepare_train_test_split(\n",
+    "    ternary_data, test_size=0.1, seed=42,\n",
+    ")\n",
+    "\n",
+    "ternary_result = train_classifier(\n",
+    "    ternary_train_ds,\n",
+    "    ternary_test_ds,\n",
+    "    ternary_test_meta,\n",
+    "    embsize=embsize,\n",
+    "    label_map=TERNARY_LABELS,\n",
+    "    lr=TERNARY_LR,\n",
+    "    epochs=TERNARY_EPOCHS,\n",
+    "    batch_size=BATCH_SIZE,\n",
+    "    use_class_weights=True,\n",
+    "    device=DEVICE,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ternary-plot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "epochs = range(1, TERNARY_EPOCHS + 1)\n",
+    "plt.figure(figsize=(8, 4))\n",
+    "plt.plot(epochs, ternary_result.train_losses, label=\"Train\")\n",
+    "plt.plot(epochs, ternary_result.test_losses, label=\"Test\")\n",
+    "plt.xlabel(\"Epoch\")\n",
+    "plt.ylabel(\"Loss\")\n",
+    "plt.title(f\"Ternary Classifier Loss, Learning Rate = {TERNARY_LR}\")\n",
+    "plt.legend()\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ternary-report",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(pd.DataFrame(ternary_result.classification_report).T.round(3))\n",
+    "print()\n",
+    "print(\"Sample predictions:\")\n",
+    "print(ternary_result.gene_predictions.head(10))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/trrust/__init__.py
+++ b/src/trrust/__init__.py
@@ -1,4 +1,10 @@
 from src.trrust.classifier import TRRClassifierModel
+from src.trrust.training import (
+    TrainingResult,
+    load_gene_embeddings,
+    prepare_train_test_split,
+    train_classifier,
+)
 from src.trrust.training_data import (
     BINARY_LABEL_NAMES,
     BINARY_LABELS,
@@ -18,6 +24,10 @@ __all__ = [
     "TRRClassifierModel",
     "TRRUSTData",
     "TRRUSTRecord",
+    "TrainingResult",
     "load_binary_trrust_data",
+    "load_gene_embeddings",
     "load_ternary_trrust_data",
+    "prepare_train_test_split",
+    "train_classifier",
 ]

--- a/src/trrust/training.py
+++ b/src/trrust/training.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import anndata
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.metrics import classification_report
+from sklearn.model_selection import train_test_split
+from torch.utils.data import DataLoader, TensorDataset
+
+from src.trrust.classifier import TRRClassifierModel
+from src.trrust.training_data import TRRUSTData
+
+
+@dataclass
+class TrainingResult:
+    """Outputs of a single train/test run of a TRRUST classifier."""
+
+    train_losses: list[float]
+    test_losses: list[float]
+    classification_report: dict
+    gene_predictions: pd.DataFrame
+
+
+def load_gene_embeddings(h5ad_path: str | Path) -> dict[str, np.ndarray]:
+    """Load per-gene average embeddings from an h5ad file into a dict.
+
+    Compatible with both scGPT and Geneformer encoded outputs: each stores
+    gene symbols in ``obs_names`` and the embedding matrix in ``.X``.
+    """
+    adata = anndata.read_h5ad(h5ad_path)
+    return {gene: adata.X[i] for i, gene in enumerate(adata.obs_names)}
+
+
+def prepare_train_test_split(
+    data: TRRUSTData,
+    test_size: float = 0.1,
+    seed: int = 42,
+) -> tuple[TensorDataset, TensorDataset, pd.DataFrame]:
+    """Stratified train/test split over a TRRUSTData object.
+
+    Returns ``(train_ds, test_ds, test_metadata)`` where ``test_metadata`` is a
+    DataFrame with ``tf`` and ``target`` columns aligned to test_ds row order,
+    so ``train_classifier`` can label predictions with gene names.
+    """
+    tf_tensor = torch.from_numpy(data.tf_embeddings).float()
+    tgt_tensor = torch.from_numpy(data.target_embeddings).float()
+    label_tensor = torch.from_numpy(data.labels).long()
+
+    indices = np.arange(len(data.records))
+    train_idx, test_idx = train_test_split(
+        indices,
+        test_size=test_size,
+        stratify=data.labels,
+        random_state=seed,
+    )
+
+    train_ds = TensorDataset(
+        tf_tensor[train_idx], tgt_tensor[train_idx], label_tensor[train_idx]
+    )
+    test_ds = TensorDataset(
+        tf_tensor[test_idx], tgt_tensor[test_idx], label_tensor[test_idx]
+    )
+    test_metadata = pd.DataFrame(
+        {
+            "tf": [data.records[i].tf for i in test_idx],
+            "target": [data.records[i].target for i in test_idx],
+        }
+    )
+    return train_ds, test_ds, test_metadata
+
+
+def _compute_class_weights(labels: torch.Tensor, n_classes: int) -> torch.Tensor:
+    class_counts = torch.bincount(labels, minlength=n_classes).float()
+    return len(labels) / (n_classes * class_counts)
+
+
+def train_classifier(
+    train_ds: TensorDataset,
+    test_ds: TensorDataset,
+    test_metadata: pd.DataFrame,
+    *,
+    embsize: int,
+    label_map: dict[str, int],
+    lr: float,
+    epochs: int,
+    batch_size: int = 64,
+    use_class_weights: bool = False,
+    device: str | torch.device | None = None,
+    seed: int = 42,
+) -> TrainingResult:
+    """Train a ``TRRClassifierModel`` on the provided train/test splits.
+
+    ``label_map`` maps string labels → integer indices (e.g. ``BINARY_LABELS``).
+    When ``use_class_weights=True``, inverse-frequency weights are computed
+    from the training-split labels and passed to ``CrossEntropyLoss``.
+    """
+    if device is None:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    device = torch.device(device)
+
+    torch.manual_seed(seed)
+
+    n_classes = len(label_map)
+    label_names = {v: k for k, v in label_map.items()}
+
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_ds, batch_size=batch_size, shuffle=False)
+
+    classifier = TRRClassifierModel(embsize=embsize, n_classes=n_classes).to(device)
+    optimizer = torch.optim.Adam(classifier.parameters(), lr=lr)
+
+    if use_class_weights:
+        train_labels = train_ds.tensors[2]
+        weights = _compute_class_weights(train_labels, n_classes).to(device)
+        criterion = torch.nn.CrossEntropyLoss(weight=weights)
+    else:
+        criterion = torch.nn.CrossEntropyLoss()
+
+    train_losses: list[float] = []
+    test_losses: list[float] = []
+    n_train = len(train_ds)
+    n_test = len(test_ds)
+
+    for _epoch in range(epochs):
+        classifier.train()
+        epoch_loss = 0.0
+        for tf_b, tgt_b, lbl_b in train_loader:
+            tf_b, tgt_b, lbl_b = tf_b.to(device), tgt_b.to(device), lbl_b.to(device)
+            logits = classifier(tf_b, tgt_b)
+            loss = criterion(logits, lbl_b)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            epoch_loss += loss.item() * len(lbl_b)
+        train_losses.append(epoch_loss / n_train)
+
+        classifier.eval()
+        test_loss = 0.0
+        with torch.no_grad():
+            for tf_b, tgt_b, lbl_b in test_loader:
+                tf_b, tgt_b, lbl_b = tf_b.to(device), tgt_b.to(device), lbl_b.to(device)
+                logits = classifier(tf_b, tgt_b)
+                test_loss += criterion(logits, lbl_b).item() * len(lbl_b)
+        test_losses.append(test_loss / n_test)
+
+    classifier.eval()
+    all_preds = []
+    all_true = []
+    with torch.no_grad():
+        for tf_b, tgt_b, lbl_b in test_loader:
+            logits = classifier(tf_b.to(device), tgt_b.to(device))
+            all_preds.append(logits.argmax(dim=1).cpu())
+            all_true.append(lbl_b)
+    preds = torch.cat(all_preds).numpy()
+    true = torch.cat(all_true).numpy()
+
+    target_names = [label_names[i] for i in range(n_classes)]
+    report = classification_report(
+        true, preds, target_names=target_names, output_dict=True, zero_division=0
+    )
+
+    predictions_df = test_metadata.reset_index(drop=True).copy()
+    predictions_df["true_relationship"] = [label_names[int(t)] for t in true]
+    predictions_df["predicted_relationship"] = [label_names[int(p)] for p in preds]
+
+    return TrainingResult(
+        train_losses=train_losses,
+        test_losses=test_losses,
+        classification_report=report,
+        gene_predictions=predictions_df,
+    )

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,211 @@
+"""Unit tests for src.trrust.training — uses synthetic data, no GPU required."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import anndata
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from src.trrust import (
+    BINARY_LABELS,
+    TERNARY_LABELS,
+    load_binary_trrust_data,
+    load_gene_embeddings,
+    load_ternary_trrust_data,
+    prepare_train_test_split,
+    train_classifier,
+)
+
+EMBSIZE = 8
+GENE_NAMES = [
+    "ABL1", "BAX", "BCL2", "MYC", "TP53", "JUN", "FOS", "EGR1",
+    "STAT1", "STAT3", "NFKB1", "RELA", "CREB1", "ATF2", "GATA1", "GATA2",
+]
+
+TSV_CONTENT = """\
+ABL1\tBAX\tActivation\t11111111
+ABL1\tBCL2\tRepression\t22222222
+BCL2\tABL1\tActivation\t33333333
+MYC\tTP53\tActivation\t44444444
+JUN\tFOS\tRepression\t55555555
+STAT1\tSTAT3\tActivation\t66666666
+NFKB1\tRELA\tActivation\t77777777
+CREB1\tATF2\tRepression\t88888888
+GATA1\tGATA2\tActivation\t99999999
+EGR1\tMYC\tRepression\t10101010
+"""
+
+
+@pytest.fixture()
+def tsv_path(tmp_path: Path) -> Path:
+    p = tmp_path / "trrust.tsv"
+    p.write_text(TSV_CONTENT)
+    return p
+
+
+@pytest.fixture()
+def gene_embeddings() -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(42)
+    return {
+        name: rng.standard_normal(EMBSIZE).astype(np.float32) for name in GENE_NAMES
+    }
+
+
+@pytest.fixture()
+def binary_data(tsv_path, gene_embeddings):
+    return load_binary_trrust_data(tsv_path, gene_embeddings, seed=42)
+
+
+@pytest.fixture()
+def ternary_data(tsv_path, gene_embeddings):
+    return load_ternary_trrust_data(tsv_path, gene_embeddings, seed=42)
+
+
+class TestLoadGeneEmbeddings:
+    def test_roundtrip(self, tmp_path):
+        gene_names = ["G1", "G2", "G3"]
+        X = np.arange(12, dtype=np.float32).reshape(3, 4)
+        adata = anndata.AnnData(X=X, obs=pd.DataFrame(index=gene_names))
+        path = tmp_path / "test.h5ad"
+        adata.write_h5ad(path)
+
+        result = load_gene_embeddings(path)
+        assert set(result.keys()) == set(gene_names)
+        assert result["G1"].shape == (4,)
+        np.testing.assert_array_equal(result["G2"], X[1])
+
+
+class TestPrepareTrainTestSplit:
+    def test_dataset_sizes(self, binary_data):
+        n = len(binary_data.records)
+        train_ds, test_ds, test_meta = prepare_train_test_split(
+            binary_data, test_size=0.2, seed=42
+        )
+        assert len(train_ds) + len(test_ds) == n
+        assert len(test_ds) == len(test_meta)
+
+    def test_metadata_columns(self, binary_data):
+        _, _, test_meta = prepare_train_test_split(binary_data, test_size=0.2)
+        assert list(test_meta.columns) == ["tf", "target"]
+
+    def test_tensor_shapes(self, binary_data):
+        train_ds, test_ds, _ = prepare_train_test_split(binary_data, test_size=0.2)
+        tf, tgt, lbl = train_ds[0]
+        assert tf.shape == (EMBSIZE,)
+        assert tgt.shape == (EMBSIZE,)
+        assert lbl.dtype == torch.int64
+
+    def test_stratification(self, binary_data):
+        _, test_ds, _ = prepare_train_test_split(
+            binary_data, test_size=0.2, seed=42
+        )
+        test_labels = test_ds.tensors[2].numpy()
+        # Binary data is balanced, so test split should contain both classes
+        assert set(test_labels.tolist()) == {0, 1}
+
+    def test_reproducibility(self, binary_data):
+        _, _, meta1 = prepare_train_test_split(binary_data, test_size=0.2, seed=7)
+        _, _, meta2 = prepare_train_test_split(binary_data, test_size=0.2, seed=7)
+        pd.testing.assert_frame_equal(meta1, meta2)
+
+
+class TestTrainClassifierBinary:
+    def test_result_fields(self, binary_data):
+        train_ds, test_ds, test_meta = prepare_train_test_split(
+            binary_data, test_size=0.2, seed=42
+        )
+        result = train_classifier(
+            train_ds, test_ds, test_meta,
+            embsize=EMBSIZE,
+            label_map=BINARY_LABELS,
+            lr=1e-3,
+            epochs=3,
+            batch_size=16,
+            device="cpu",
+        )
+        assert len(result.train_losses) == 3
+        assert len(result.test_losses) == 3
+        assert all(isinstance(x, float) for x in result.train_losses)
+        assert "accuracy" in result.classification_report
+        assert "None" in result.classification_report
+        assert "Relationship" in result.classification_report
+
+    def test_predictions_dataframe(self, binary_data):
+        train_ds, test_ds, test_meta = prepare_train_test_split(
+            binary_data, test_size=0.2, seed=42
+        )
+        result = train_classifier(
+            train_ds, test_ds, test_meta,
+            embsize=EMBSIZE,
+            label_map=BINARY_LABELS,
+            lr=1e-3,
+            epochs=2,
+            batch_size=16,
+            device="cpu",
+        )
+        df = result.gene_predictions
+        assert list(df.columns) == [
+            "tf", "target", "true_relationship", "predicted_relationship"
+        ]
+        assert len(df) == len(test_ds)
+        valid_labels = set(BINARY_LABELS.keys())
+        assert set(df["true_relationship"]).issubset(valid_labels)
+        assert set(df["predicted_relationship"]).issubset(valid_labels)
+
+
+class TestTrainClassifierTernary:
+    def test_weighted(self, ternary_data):
+        train_ds, test_ds, test_meta = prepare_train_test_split(
+            ternary_data, test_size=0.2, seed=42
+        )
+        result = train_classifier(
+            train_ds, test_ds, test_meta,
+            embsize=EMBSIZE,
+            label_map=TERNARY_LABELS,
+            lr=1e-3,
+            epochs=2,
+            batch_size=16,
+            use_class_weights=True,
+            device="cpu",
+        )
+        assert len(result.train_losses) == 2
+        for name in TERNARY_LABELS:
+            assert name in result.classification_report
+
+    def test_unweighted(self, ternary_data):
+        train_ds, test_ds, test_meta = prepare_train_test_split(
+            ternary_data, test_size=0.2, seed=42
+        )
+        result = train_classifier(
+            train_ds, test_ds, test_meta,
+            embsize=EMBSIZE,
+            label_map=TERNARY_LABELS,
+            lr=1e-3,
+            epochs=2,
+            batch_size=16,
+            use_class_weights=False,
+            device="cpu",
+        )
+        assert len(result.train_losses) == 2
+
+
+class TestReproducibility:
+    def test_same_seed_same_losses(self, binary_data):
+        train_ds, test_ds, test_meta = prepare_train_test_split(
+            binary_data, test_size=0.2, seed=42
+        )
+        r1 = train_classifier(
+            train_ds, test_ds, test_meta,
+            embsize=EMBSIZE, label_map=BINARY_LABELS,
+            lr=1e-3, epochs=3, batch_size=16, device="cpu", seed=123,
+        )
+        r2 = train_classifier(
+            train_ds, test_ds, test_meta,
+            embsize=EMBSIZE, label_map=BINARY_LABELS,
+            lr=1e-3, epochs=3, batch_size=16, device="cpu", seed=123,
+        )
+        assert r1.train_losses == r2.train_losses


### PR DESCRIPTION
**Summary**

1. Create functions for scfm-agnostic classifier training under src/trrust
2. Test classifier functions ( binary/ternary, reproducibility, etc.)
3. Output results as TrainingResult dataclass (train/test losses, classification report, predictions dataframe)
4. Create scfm-agnostic notebook to train binary/ternary classifiers using 90/10 stratified train/test split


**Next Steps**

1. Update training notebook to train 5x5 classifiers on varying LR and epochs, and save results for comparison
2. Update training notebook to do stratified 5-fold cross validation on optimal results from (1) and save output TrainingResult to file
3. Create results notebook to compare TrainingResult across datasets